### PR TITLE
MPFix+DevicePassing

### DIFF
--- a/fnc/fn_deviceSettings.sqf
+++ b/fnc/fn_deviceSettings.sqf
@@ -37,20 +37,22 @@ if ((_minSelection < _minFreq) || (_maxSelection > _maxFreq)) then
 	["Selection range not within frequency range: Frequency Range: %1-%2. Selection Range: %3-%4",_minFreq,_maxFreq,_minSelection,_maxSelection] call BIS_fnc_error;
 };
 
-missionNamespace setVariable ["#EM_FMin", _minFreq];
-missionNamespace setVariable ["#EM_FMax", _maxFreq];
+missionNamespace setVariable ["#EM_FMin", _minFreq, true];
+missionNamespace setVariable ["#EM_FMax", _maxFreq, true];
 
-missionNamespace setVariable ["#EM_SMin", _minStrength];
-missionNamespace setVariable ["#EM_SMax", _maxStrength];
+missionNamespace setVariable ["#EM_SMin", _minStrength, true];
+missionNamespace setVariable ["#EM_SMax", _maxStrength, true];
 
-missionNamespace setVariable ["#EM_SelMin", _minSelection];
-missionNamespace setVariable ["#EM_SelMax", _maxSelection];
+missionNamespace setVariable ["#EM_SelMin", _minSelection, true];
+missionNamespace setVariable ["#EM_SelMax", _maxSelection, true];
 
-missionNamespace setVariable ["#EM_Values", [0,0]];
+missionNamespace setVariable ["#EM_Values", [0,0], true];
 
 signalNameArray = [0];
 signalNameArray deleteAt 0;
+publicVariable "signalNameArray";
 nameArray = ["0"];
 nameArray deleteAt 0;
+publicVariable "nameArray";
 
 deleteVehicle _module;

--- a/fnc/fn_signalReceiver.sqf
+++ b/fnc/fn_signalReceiver.sqf
@@ -5,12 +5,31 @@
 // Date: 06/07/20
 // Description: Sets the spectrumDestination global variable, all spectrum sources will measure their distance from this destination.
 //======================================================================================================================================================
-private ["_module","_syncArray"];
+private ["_module","_syncArray","_deviceUpdate"];
 
 _module = param [0, objNull, [objNull]];
 if (isNull _module) exitWith {deleteVehicle _module};
 
-_syncArray = synchronizedObjects _module;
-spectrumDestination = _syncArray select 0;
+_receiverMethod = _module getVariable "specdev_spectrumDestination_Method";
+
+if (_receiverMethod == 0) then
+{
+	_syncArray = synchronizedObjects _module;
+	spectrumDestination = _syncArray select 0;
+	publicVariable "spectrumDestination";
+}else{
+	_deviceUpdate = _module getVariable "specdev_spectrumDestination_deviceUpdate";
+	while {true} do
+	{		
+		{
+			if ("hgun_esd_" in handgunWeapon _x) then
+			{
+				spectrumDestination = _x;
+				publicVariable "spectrumDestination";
+			};
+		} forEach allPlayers;
+		sleep _deviceUpdate;
+	};
+};
 
 deleteVehicle _module;

--- a/fnc/fn_signalSource.sqf
+++ b/fnc/fn_signalSource.sqf
@@ -12,15 +12,16 @@ private _object = [];
 private _objectArray = [];
 //==============================================================
 
-if (isNil {spectrumDestination}) exitWith
-{
-	["No destination set. Spectrum Destination module must be synced with receiver unit"] call BIS_fnc_error;
-};
-
 //===============Assign module object to variable===============
 _module = param [0, objNull, [objNull]];
 if (isNull _module) exitWith {deleteVehicle _module};
 //==============================================================
+
+
+if (isNil {spectrumDestination}) then
+{
+	waitUntil {!isNil {spectrumDestination}};
+};
 
 //===============Exit function if signal name is duplicated===============
 _signalName = _module getVariable "specdev_spectrumSource_Name";
@@ -77,11 +78,12 @@ if (_frequency < _minFreq || _frequency > _maxFreq) exitWith
 _freqCheck append [_frequency,_minStrength];
 _arrayFrequency = (count _freqCheck - 2); //Persistent identifier of the frequnecy added to #EM_Values
 _arrayStrength = (count _freqCheck - 1); //Persistent identifier of frequency strength added to #EM_Values
-missionNamespace setVariable ["#EM_Values",_freqCheck];
-
+missionNamespace setVariable ["#EM_Values",_freqCheck, true];
 
 signalNameArray append [[_signalName,_arrayStrength,1]];
+publicVariable "signalNameArray";
 nameArray append [_signalName];
+publicVariable "nameArray";
 
 _signalPath = [signalNameArray, _signalName] call BIS_fnc_findNestedElement;
 _signalPath set [1,2];
@@ -140,7 +142,7 @@ while {alive _objectVar && (([signalNameArray, _signalPath] call BIS_fnc_returnN
 		_freqCheck = missionNamespace getVariable "#EM_Values";
 
 		_freqCheck set [_arrayStrength, _strength];
-		missionNamespace setVariable ["#EM_Values",_freqCheck];
+		missionNamespace setVariable ["#EM_Values",_freqCheck, true];
 	}
 	//===============================================================================================
 	//===============If source object isn't within 90 degrees then set frequency strength to minimum===============
@@ -148,10 +150,10 @@ while {alive _objectVar && (([signalNameArray, _signalPath] call BIS_fnc_returnN
 	{
 		_freqCheck = missionNamespace getVariable "#EM_Values";
 		_freqCheck set [_arrayStrength, _minStrength];
-		missionNamespace setVariable ["#EM_Values",_freqCheck];
+		missionNamespace setVariable ["#EM_Values",_freqCheck, true];
 	};
 	//=============================================================================================================
-
+	hint format ["%1",_freqCheck];
 	//===============Re-run the 'while' after _delay seconds===============
 	sleep _delay;
 	//=====================================================================
@@ -162,7 +164,7 @@ while {alive _objectVar && (([signalNameArray, _signalPath] call BIS_fnc_returnN
 if (!alive _objectVar || (([signalNameArray, _signalPath] call BIS_fnc_returnNestedElement) == 0)) exitWith {
 	_freqCheck = missionNamespace getVariable "#EM_Values";
 	_freqCheck set [_arrayStrength, _minStrength];
-	missionNamespace setVariable ["#EM_Values",_freqCheck];
+	missionNamespace setVariable ["#EM_Values",_freqCheck, true];
 	deleteVehicle _module;
 };
 //=====================================================================================================

--- a/specdev_Module_spectrumDestination.hpp
+++ b/specdev_Module_spectrumDestination.hpp
@@ -13,17 +13,48 @@ class specdev_Module_spectrumDestination: Module_F
 
     class Attributes: AttributesBase
     {
+        class specdev_spectrumDestination_Method: Combo
+        {
+            property = "specdev_spectrumDestination_Method";
+            displayName = "Receiving Method";
+            tooltip = "Sets how the module will decide the signal receiver. One Unit: Same unit will always act as the signal receiver. One Device: Player holding device will act as the signal receiver, should only have a single Spectrum Device available in the mission at a time.";
+            typeName = "NUMBER";
+            defaultValue = "0";
+            class Values
+            {
+                class specdev_spectrumDestination_Method_oneUnit
+                {
+                    name = "One Unit";
+                    value = 0;
+                };
+                class specdev_spectrumDestination_Method_oneDevice
+                {
+                    name = "One Device";
+                    value = 1;
+                };
+            };
+        };
+        class specdev_spectrumDestination_deviceUpdate: Edit
+        {
+            property = "specdev_spectrumDestination_deviceUpdate";
+            displayName = "Signal Receiver Update";
+            tooltip = "When using One Device mode, how often will the module check who is holding the device in seconds.";
+            typeName = "NUMBER";
+            defaultValue = "60";
+        };
+
         class ModuleDescription: ModuleDescription{};
     };
 
     class ModuleDescription: ModuleDescription
     {
         description[] = {
-            "This module sets which unit will be the receiver for signals.",
-            "Sync to player that will receive signals.",
-            "Must only have a SINGLE Destination module!",
-            "Additional modules will overwrite the previous ones.",
-            "Can sync to non-players if required, however anything that happens as a result of this is unintended.";
+            "Sets the method of receiving signals",
+            "One Unit: Same unit will always receive the signals, regardless of who's holding the Spectrum Device",
+            "One Device: Player holding the Spectrum Device will receive the signals, should only have a single Spectrum Device available at a time in the mission",
+            "When multiple devices are used, any results are unintended.",
+            "Module can be trigger activated, can be used with One Receiver mode to overwrite who is acting as the Receiver.",
+            "Don't use both types of Receiving Methods simultaneously!";
         };
         position = 0;
         direction = 0;


### PR DESCRIPTION
Fixed MP issues by having the global variable values made public after they are set.
Added option in Spectrum Receiver module so that the Receiver can either be set to a single unit, as it currently is, or single device. Single device will mean that when a single device is being used it can be passed between players and it will remain accurate. When multiple devices are used, the last player in the order their units were created will be the accurate receiver.